### PR TITLE
React18から17へのバージョンダウン

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -2,15 +2,16 @@
   "name": "front",
   "version": "0.1.0",
   "private": true,
-  "dependencies": {
-    "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^13.4.0",
-    "@testing-library/user-event": "^13.5.0",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "react-scripts": "5.0.1",
-    "web-vitals": "^2.1.4"
-  },
+  "dependencies": {  
+    "@testing-library/jest-dom": "^5.16.2",   
+    "@testing-library/react": "^11.2.7",  
+    "@testing-library/user-event": "^12.8.3",  
+    "react": "^17.0.2",    
+    "react-beautiful-dnd": "^13.1.0",    
+    "react-dom": "^17.0.2",    
+    "react-scripts": "5.0.0",   
+    "web-vitals": "^0.2.4"  
+},
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",

--- a/front/src/index.js
+++ b/front/src/index.js
@@ -1,17 +1,15 @@
 import React from 'react';
-import ReactDOM from 'react-dom/client';
+import ReactDOM from 'react-dom';
 import './index.css';
-import App from './App';
-import reportWebVitals from './reportWebVitals';
+import App from './App'; 
 
-const root = ReactDOM.createRoot(document.getElementById('root'));
-root.render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
+ReactDOM.render(
+    <React.StrictMode>
+        <App />  
+    </React.StrictMode>,  
+    document.getElementById('root')
 );
 
 // If you want to start measuring performance in your app, pass a function
 // to log results (for example: reportWebVitals(console.log))
 // or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
-reportWebVitals();


### PR DESCRIPTION
### 変更内容
React18から17へのバージョンダウン
### 背景・目的
dockerで環境作ると思うけどpackage.jsonの中身がreact立てた時18になっているのでnpm installすると18になるためグレードダウン+それに伴うindex.jsの変更

### 関連issue
<!-- 関連するissueがあれば、番号を使ってリンクしてください (例: fixes #123) -->

### 変更方法
package.jsonの依存関係のところ変更

### テスト方法
<!-- この変更に関連するテスト方法や確認方法を説明してください -->

### 追加情報
<!-- その他、このプルリクエストに関連する情報があれば記載してください -->

